### PR TITLE
move headPose initialization into GVRRenderer constructor

### DIFF
--- a/Samples/GVRKit/GVRRenderer.mm
+++ b/Samples/GVRKit/GVRRenderer.mm
@@ -54,6 +54,13 @@ static const uint64_t kPredictionTimeWithoutVsyncNanos = 50000000;
 
 @implementation GVRRenderer
 
+- (instancetype)init {
+  if (self = [super init]) {
+    _headPose = [[GVRHeadPose alloc] init];
+  }
+  return self;
+}
+
 - (void)initializeGl {
   _gvrApi = gvr::GvrApi::Create();
   _gvrApi->InitializeGl();
@@ -64,7 +71,6 @@ static const uint64_t kPredictionTimeWithoutVsyncNanos = 50000000;
   _swapchain.reset(new gvr::SwapChain(_gvrApi->CreateSwapChain(specs)));
   _viewportList.reset(new gvr::BufferViewportList(_gvrApi->CreateEmptyBufferViewportList()));
 
-  _headPose = [[GVRHeadPose alloc] init];
   _headRotation = GLKMatrix4Identity;
 }
 


### PR DESCRIPTION
I have a scene renderer declared like this in a `GVRRendererViewController` subclass:
```
    private lazy var sceneRenderer: GVRSceneRenderer = {
        let sr = GVRSceneRenderer()
        sr.hidesReticle = true
        sr.renderList.add(self.videoRenderer)
        sr.add(toHeadRotationYaw: 0, andPitch: -0.125)  // <--- doesn't work
        return sr
    }()
```
Adding yaw or pitch doesn't work like this. It turns out `_headPose` is null on [line 123](https://github.com/googlevr/gvr-ios-sdk/blob/master/Samples/GVRKit/GVRRenderer.mm#L123) in GVRRenderer.mm.

Moving that call to `viewDidLoad` in the view controller didn't help, but moving it to `viewDidAppear` fixed the problem. `headPose` isn't allocated until `initializeGl` is called so it makes sense that it would exist once the view has been painted.

Moving `headpose` initialization into `GVRRenderer`'s init makes this API a little more friendly.

Thank you for GVRKit. It's a million times better than the old APIs. And extra kudos for making it open source.