### PR TITLE
Fixes garbage being shown when rendering views with transparency

### DIFF
--- a/Samples/GVRKit/GVRSceneRenderer.mm
+++ b/Samples/GVRKit/GVRSceneRenderer.mm
@@ -51,6 +51,10 @@
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   glEnable(GL_DEPTH_TEST);
   glEnable(GL_SCISSOR_TEST);
+
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
   checkGLError("update");
 
   [_renderList update:headPose];

--- a/Samples/GVRKit/GVRUIViewRenderer.mm
+++ b/Samples/GVRKit/GVRUIViewRenderer.mm
@@ -128,6 +128,9 @@ static constexpr float kDefaultEpsilon = 1.0e-5f;
                                                CVPixelBufferGetBytesPerRow(_pixelBuffer),
                                                colorSpace,
                                                kCGImageAlphaPremultipliedLast);
+
+  CGContextClearRect(context, _view.bounds);
+
   CGColorSpaceRelease(colorSpace);
   NSAssert(context != NULL, @"Error creating bitmap context.");
 


### PR DESCRIPTION
I tried rendering views with transparency (UILabel with clear background, image with transparency in UIImageView, etc.) but there were random colors shown in place of transparency.

I fixed it by clearing the context before using it for view rendering, but then the background was black, so I noticed alpha blending was not enabled.