### PR TITLE
- added support for OpenGLES2

### DIFF
--- a/Samples/GVRKit/GVRRendererView.mm
+++ b/Samples/GVRKit/GVRRendererView.mm
@@ -67,6 +67,9 @@ private:
     [self addGestureRecognizer:panGesture];
 
     self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
+    if (self.context == nil) {
+        self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    }
     self.drawableDepthFormat = GLKViewDrawableDepthFormat16;
 
     [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
As discussed here:

https://github.com/googlevr/gvr-ios-sdk/issues/288

there is a problem of GVRKit not running on older devices with openGLES2.

According to Apple documentation:

https://developer.apple.com/library/content/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/WorkingwithOpenGLESContexts/WorkingwithOpenGLESContexts.html

It should be initialised as fallback